### PR TITLE
(HS2) Fix the ChaControl.UpdateWet NullReferenceException

### DIFF
--- a/IllusionFixes.sln
+++ b/IllusionFixes.sln
@@ -221,6 +221,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EC_Fix_GuideObjects", "src\
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Core_Fix_GuideObjects", "src\Core_Fix_GuideObjects\Core_Fix_GuideObjects.shproj", "{763D7633-B7FD-4B91-886B-579850E2FAE1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HS2_Fix_UpdateWet", "src\HS2_Fix_UpdateWet\HS2_Fix_UpdateWet.csproj", "{BDB643DB-EE18-4620-AF42-0BD66B829240}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Common\Common.projitems*{020992e5-0e49-4b83-a3ce-c5eb990edda7}*SharedItemsImports = 4
@@ -335,6 +337,7 @@ Global
 		src\Core_Fix_StudioOptimizations\Core_Fix_StudioOptimizations.projitems*{b3a37bdb-238f-47a7-9a73-1c15ea1a05ab}*SharedItemsImports = 4
 		src\Common\Common.projitems*{b50199ca-ba76-4628-8e86-2a2b40e40520}*SharedItemsImports = 4
 		src\Core_Fix_DynamicBones\Core_Fix_DynamicBones.projitems*{b50199ca-ba76-4628-8e86-2a2b40e40520}*SharedItemsImports = 4
+		src\Common\Common.projitems*{bdb643db-ee18-4620-af42-0bd66b829240}*SharedItemsImports = 4
 		src\Common\Common.projitems*{be04b9fb-6862-49df-a8d1-26e185f0d9b8}*SharedItemsImports = 4
 		src\Common\Common.projitems*{bf58115b-8249-4f38-9f73-96cddda819e1}*SharedItemsImports = 4
 		src\Core_Fix_CameraTarget\Core_Fix_CameraTarget.projitems*{bf58115b-8249-4f38-9f73-96cddda819e1}*SharedItemsImports = 4
@@ -660,6 +663,10 @@ Global
 		{89AFBE74-7A61-4A50-A01E-40E35B9407E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{89AFBE74-7A61-4A50-A01E-40E35B9407E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{89AFBE74-7A61-4A50-A01E-40E35B9407E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BDB643DB-EE18-4620-AF42-0BD66B829240}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BDB643DB-EE18-4620-AF42-0BD66B829240}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BDB643DB-EE18-4620-AF42-0BD66B829240}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BDB643DB-EE18-4620-AF42-0BD66B829240}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/HS2_Fix_UpdateWet/FixUpdateWet.cs
+++ b/src/HS2_Fix_UpdateWet/FixUpdateWet.cs
@@ -1,0 +1,72 @@
+﻿using AIChara;
+using BepInEx;
+using BepInEx.Logging;
+using Common;
+using HarmonyLib;
+using System.Linq;
+using UnityEngine;
+
+namespace IllusionFixes
+{
+    [BepInPlugin(GUID, PluginName, Constants.PluginsVersion)]
+    public class FixUpdateWet : BaseUnityPlugin
+    {
+        public const string GUID = "HS2_Fix_UpdateWet";
+        public const string PluginName = "Fix UpdateWet Exceptions";
+
+        private static FixUpdateWet Instance;
+
+        private ManualLogSource Log => Logger;
+
+        public void Start()
+        {
+            Instance = this;
+            PatchMe();
+        }
+
+        private static void PatchMe()
+        {
+            Harmony harmony = new Harmony(GUID);
+            harmony.PatchAll(typeof(FixUpdateWet));
+        }
+
+        // Some modded items have null renderers in the CmpHair or CmpClothes MB setup
+        // This is harmless everywhere but throws an error in ChaControl.UpdateWet which causes wet effects to not apply properly and a major logging
+        // driven performance hit
+
+        // This fixes it by simply removing the non-existent renderer from the array which *I think* is entirely safe...doesn't seem to cause an issue
+        // I mean, the renderer isn't there anyway...hence it being null ;)
+
+        [HarmonyPrefix, HarmonyPatch(typeof(ChaControl), "UpdateWet")]
+        static void UpdateWetPreHook(ChaControl __instance)
+        {
+            // Cleanup broken renderers
+            foreach (CmpHair hair in __instance.cmpHair)
+            {         
+                if (hair != null && hair.rendHair != null && hair.rendHair.Contains(null))
+                {
+                    hair.rendHair = hair.rendHair.Where(r => r != null).ToArray();
+                }
+                if (hair != null && hair.rendAccessory != null && hair.rendAccessory.Contains(null))
+                {
+                    hair.rendAccessory = hair.rendAccessory.Where(r => r != null).ToArray();
+                }
+            }
+            foreach (CmpClothes clothes in __instance.cmpClothes)
+            {
+                if (clothes != null && clothes.rendNormal01 != null && clothes.rendNormal01.Contains(null))
+                {
+                    clothes.rendNormal01 = clothes.rendNormal01.Where(r => r != null).ToArray();
+                }
+                if (clothes != null && clothes.rendNormal02 != null && clothes.rendNormal02.Contains(null))
+                {
+                    clothes.rendNormal02 = clothes.rendNormal02.Where(r => r != null).ToArray();
+                }
+                if (clothes != null && clothes.rendNormal03 != null && clothes.rendNormal03.Contains(null))
+                {
+                    clothes.rendNormal03 = clothes.rendNormal03.Where(r => r != null).ToArray();
+                }
+            }
+        }
+    }
+}

--- a/src/HS2_Fix_UpdateWet/HS2_Fix_UpdateWet.csproj
+++ b/src/HS2_Fix_UpdateWet/HS2_Fix_UpdateWet.csproj
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{BDB643DB-EE18-4620-AF42-0BD66B829240}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>IllusionFixes</RootNamespace>
+    <AssemblyName>HS2_Fix_UpdateWet</AssemblyName>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>embedded</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\bin\BepInEx\plugins\IllusionFixes\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;HS2</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\bin\BepInEx\plugins\IllusionFixes\</OutputPath>
+    <DefineConstants>TRACE;HS2</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="0Harmony, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\IllusionLibs.BepInEx.Harmony.2.2.0.1\lib\net35\0Harmony.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp.2020.5.29.2\lib\net46\Assembly-CSharp.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass.2020.5.29.2\lib\net46\Assembly-CSharp-firstpass.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BepInEx, Version=5.4.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\IllusionLibs.BepInEx.5.4.4\lib\net35\BepInEx.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BepInEx.Harmony, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\IllusionLibs.BepInEx.Harmony.2.2.0.1\lib\net35\BepInEx.Harmony.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11.2\lib\net46\UnityEngine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11.2\lib\net46\UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="FixUpdateWet.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="..\Common\Common.projitems" Label="Shared" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp.2020.5.29.2\build\IllusionLibs.HoneySelect2.Assembly-CSharp.targets" Condition="Exists('..\..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp.2020.5.29.2\build\IllusionLibs.HoneySelect2.Assembly-CSharp.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp.2020.5.29.2\build\IllusionLibs.HoneySelect2.Assembly-CSharp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp.2020.5.29.2\build\IllusionLibs.HoneySelect2.Assembly-CSharp.targets'))" />
+    <Error Condition="!Exists('..\..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass.2020.5.29.2\build\IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass.2020.5.29.2\build\IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass.targets'))" />
+    <Error Condition="!Exists('..\..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11.2\build\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11.2\build\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.targets'))" />
+    <Error Condition="!Exists('..\..\packages\IllusionLibs.BepInEx.Harmony.2.2.0.1\build\IllusionLibs.BepInEx.Harmony.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\IllusionLibs.BepInEx.Harmony.2.2.0.1\build\IllusionLibs.BepInEx.Harmony.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass.2020.5.29.2\build\IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass.targets" Condition="Exists('..\..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass.2020.5.29.2\build\IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass.targets')" />
+  <Import Project="..\..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11.2\build\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.targets" Condition="Exists('..\..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11.2\build\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.targets')" />
+  <Import Project="..\..\packages\IllusionLibs.BepInEx.Harmony.2.2.0.1\build\IllusionLibs.BepInEx.Harmony.targets" Condition="Exists('..\..\packages\IllusionLibs.BepInEx.Harmony.2.2.0.1\build\IllusionLibs.BepInEx.Harmony.targets')" />
+</Project>

--- a/src/HS2_Fix_UpdateWet/Properties/AssemblyInfo.cs
+++ b/src/HS2_Fix_UpdateWet/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿using System.Reflection;
+
+[assembly: AssemblyTitle(IllusionFixes.FixUpdateWet.GUID)]
+[assembly: AssemblyProduct(IllusionFixes.FixUpdateWet.GUID)]
+[assembly: AssemblyDescription(IllusionFixes.FixUpdateWet.PluginName)]

--- a/src/HS2_Fix_UpdateWet/packages.config
+++ b/src/HS2_Fix_UpdateWet/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="IllusionLibs.BepInEx" version="5.4.4" targetFramework="net471" />
+  <package id="IllusionLibs.BepInEx.Harmony" version="2.2.0.1" targetFramework="net471" />
+  <package id="IllusionLibs.HoneySelect2.Assembly-CSharp" version="2020.5.29.2" targetFramework="net471" />
+  <package id="IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass" version="2020.5.29.2" targetFramework="net471" />
+  <package id="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" version="2018.4.11.2" targetFramework="net471" />
+</packages>


### PR DESCRIPTION
This tends to happen with some mods ported from AIS, they have CmpHair or CmpClothes MB setups with a null renderer in the array. Most of Illusion code handles this but the ChaControl.UpdateWet doesn't handle the NullReference and spams the following error per frame:

NullReferenceException: Object reference not set to an instance of an object
  at AIChara.ChaControl.UpdateWet () [0x001b5] in <f4b3ed4e035748eda610b0642947f317>:0 
  at AIChara.ChaControl.UpdateForce () [0x0001f] in <f4b3ed4e035748eda610b0642947f317>:0 
  at Manager.Character.Update () [0x00026] in <f4b3ed4e035748eda610b0642947f317>:0 

This fix simply scans for and removes null renderers from the renderer array, thus fixing the not fully applied wet effects and more importantly the performance hit on the constant log spam.