### PR TITLE
[KK][GT] Use a nonallocating equality comparer for ChaReference

### DIFF
--- a/src/KK_Fix_GarbageTruck/GarbageTruck.cs
+++ b/src/KK_Fix_GarbageTruck/GarbageTruck.cs
@@ -359,6 +359,7 @@ namespace IllusionFixes
             /// </summary>
             [HarmonyPatch(typeof(ChaReference), MethodType.Constructor)]
             [HarmonyPostfix]
+            [HarmonyPriority(Priority.First)]
             private static void FixChaReferenceComparer(ChaReference __instance)
             {
                 var dic = new Dictionary<ChaReference.RefObjKey, GameObject>(

--- a/src/KK_Fix_GarbageTruck/GarbageTruck.cs
+++ b/src/KK_Fix_GarbageTruck/GarbageTruck.cs
@@ -353,6 +353,31 @@ namespace IllusionFixes
                     .RemoveInstruction()
                     .Instructions();
             }
+
+            /// <summary>
+            /// Use a nonallocating equality comparer for ChaReference.dictRefObj.
+            /// </summary>
+            [HarmonyPatch(typeof(ChaReference), MethodType.Constructor)]
+            [HarmonyPostfix]
+            private static void FixChaReferenceComparer(ChaReference __instance)
+            {
+                var dic = new Dictionary<ChaReference.RefObjKey, GameObject>(
+                    __instance.dictRefObj,
+                    new RefObjKeyEqualityComparer());
+                __instance.dictRefObj = dic;
+            }
+            class RefObjKeyEqualityComparer : IEqualityComparer<ChaReference.RefObjKey>
+            {
+                public bool Equals(ChaReference.RefObjKey x, ChaReference.RefObjKey y)
+                {
+                    return x == y;
+                }
+
+                public int GetHashCode(ChaReference.RefObjKey x)
+                {
+                    return ((int)x).GetHashCode();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The default equality comparer for enums incurs boxing overhead. This is fixed by using a custom equality comparer.

This issue doesn't affect KKS because the newer version of mscorlib has a nonallocating default equality comparer for enums.