### PR TITLE
[KK][GT] Cache temporary arrays in ChaControl.UpdateVisible

### DIFF
--- a/src/KK_Fix_GarbageTruck/GarbageTruck.cs
+++ b/src/KK_Fix_GarbageTruck/GarbageTruck.cs
@@ -387,8 +387,7 @@ namespace IllusionFixes
             [HarmonyPatch(typeof(ChaControl), nameof(ChaControl.UpdateVisible))]
             private static IEnumerable<CodeInstruction> FixUpdateVisible(IEnumerable<CodeInstruction> insts)
             {
-                var originalInstList = insts.ToList();
-                var matcher = new CodeMatcher(originalInstList);
+                var matcher = new CodeMatcher(insts);
                 var get1DArray = AccessTools.Method(typeof(AntiGarbageHooks), nameof(Get1DArrayForUpdateVisible));
                 var get2DArray = AccessTools.Method(typeof(AntiGarbageHooks), nameof(Get2DArrayForUpdateVisible));
                 var array2DTypes = new Dictionary<Type, Type> {
@@ -428,7 +427,7 @@ namespace IllusionFixes
                 if (id != _updateVisibleAllocationCount)
                 {
                     Utilities.Logger.LogWarning($"Unexpected number of array allocations in UpdateVisible ({id}). Not patching.");
-                    return originalInstList;
+                    return insts;
                 }
                 Array.Clear(_updateVisibleArrays, 0, _updateVisibleAllocationCount);
                 return matcher.Instructions();

--- a/src/KK_Fix_GarbageTruck/GarbageTruck.cs
+++ b/src/KK_Fix_GarbageTruck/GarbageTruck.cs
@@ -424,16 +424,16 @@ namespace IllusionFixes
                                 new CodeInstruction(OpCodes.Call, get2DArray));
                         id++;
                     });
-                if (id != _updateVisibleAllocationCount)
+                if (id != ExpectedUpdateVisibleAllocationCount)
                 {
                     Utilities.Logger.LogWarning($"Unexpected number of array allocations in UpdateVisible ({id}). Not patching.");
                     return insts;
                 }
-                Array.Clear(_updateVisibleArrays, 0, _updateVisibleAllocationCount);
+                Array.Clear(_updateVisibleArrays, 0, ExpectedUpdateVisibleAllocationCount);
                 return matcher.Instructions();
             }
-            private static readonly int _updateVisibleAllocationCount = 45;
-            private static Array[] _updateVisibleArrays = new Array[_updateVisibleAllocationCount];
+            private const int ExpectedUpdateVisibleAllocationCount = 45;
+            private static Array[] _updateVisibleArrays = new Array[ExpectedUpdateVisibleAllocationCount];
             private static Array Get1DArrayForUpdateVisible(int size, int id, RuntimeTypeHandle typeHandle)
             {
                 var arr = _updateVisibleArrays[id];


### PR DESCRIPTION
This is another attempt at 3124e14, which got reverted.

The previous patch broke ClothesToAccessories when UpdateVisible contained an unexpected number of array allocations. This happened because the transpiler threw an exception, which, depending on the patch order, could prevent the transpiler defined by ClothesToAccessories (or any other plugin that patches the method) from running.

This version avoids the issue by logging an error instead of throwing an exception.

This version also removes the use of CodeMatcher.SetAndAdvance because it looks like it could destructively modify input code.

Tested with ClothesToAccessories 1.0.3.