### PR TITLE
[MapLights] Add setting to toggle warning

### DIFF
--- a/src/KK_Fix_UnlimitedMapLights/UnlimitedMapLights.cs
+++ b/src/KK_Fix_UnlimitedMapLights/UnlimitedMapLights.cs
@@ -4,6 +4,7 @@ using HarmonyLib;
 using System.Collections.Generic;
 using System.Reflection.Emit;
 using BepInEx.Logging;
+using BepInEx.Configuration;
 
 namespace IllusionFixes
 {
@@ -16,16 +17,21 @@ namespace IllusionFixes
 
         private static new ManualLogSource Logger;
 
+        private static ConfigEntry<bool> showWarning;
+
         private void Awake()
         {
             Logger = base.Logger;
+
+            showWarning = Config.Bind("Logging", "Show Maplight Warning", true, "Toggle the Warning that gets displayed if more than two maplights are added to the scene");
+
             Harmony.CreateAndPatchAll(typeof(UnlimitedMapLights));
         }
 
         [HarmonyPostfix, HarmonyPatch(typeof(Studio.SceneInfo), nameof(Studio.SceneInfo.AddLight))]
         private static void UnlimitedLights(Studio.SceneInfo __instance)
         {
-            if(__instance.lightCount > 2)
+            if(__instance.lightCount > 2 && showWarning.Value)
                 Logger.LogMessage("Warning: Lights above 2 might not affect characters and some items!");
         }
 


### PR DESCRIPTION
People are annoyed by the warning and V+ supports more than 2 MapLights so it's not even correct most of the time. 