### PR TITLE
[Studio] Fixed a bug where the initial rotation amount kept being applied to IK

### DIFF
--- a/src/Core_Fix_StudioOptimizations/Core_Fix_StudioOptimizations.projitems
+++ b/src/Core_Fix_StudioOptimizations/Core_Fix_StudioOptimizations.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)FindLoopAssistant.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FixGuideObject.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MeasuringSceneLoadTimes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StudioOptimizations.cs" />
   </ItemGroup>

--- a/src/Core_Fix_StudioOptimizations/FixGuideObject.cs
+++ b/src/Core_Fix_StudioOptimizations/FixGuideObject.cs
@@ -1,15 +1,7 @@
 ﻿using BepInEx;
-using BepInEx.Logging;
 using HarmonyLib;
 using Studio;
-using System;
-using System.Text;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection.Emit;
 using UnityEngine;
-using UnityEngine.UI;
 
 namespace IllusionFixes
 {
@@ -21,7 +13,7 @@ namespace IllusionFixes
         {
             if( !__instance.m_Enables[1] && __instance.transformTarget != null && __instance.mode == GuideObject.Mode.LocalIK )
             {
-                //Initialize rotation so that IKs with invalid rotation follow the parent's rotation
+                //Initialize rotation so that IKs with disabled rotation follow the parent's rotation
                 __instance.transformTarget.localRotation = Quaternion.identity;
             }
         }

--- a/src/Core_Fix_StudioOptimizations/FixGuideObject.cs
+++ b/src/Core_Fix_StudioOptimizations/FixGuideObject.cs
@@ -1,0 +1,29 @@
+﻿using BepInEx;
+using BepInEx.Logging;
+using HarmonyLib;
+using Studio;
+using System;
+using System.Text;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace IllusionFixes
+{
+    public partial class StudioOptimizations : BaseUnityPlugin
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(Studio.GuideObject), nameof(Studio.GuideObject.CalcRotation))]
+        private static void GuideObjectCalcRotationPrefix(Studio.GuideObject __instance)
+        {
+            if( !__instance.m_Enables[1] && __instance.transformTarget != null && __instance.mode == GuideObject.Mode.LocalIK )
+            {
+                //Initialize rotation so that IKs with invalid rotation follow the parent's rotation
+                __instance.transformTarget.localRotation = Quaternion.identity;
+            }
+        }
+    }
+}

--- a/src/Core_Fix_StudioOptimizations/FixGuideObject.cs
+++ b/src/Core_Fix_StudioOptimizations/FixGuideObject.cs
@@ -11,7 +11,7 @@ namespace IllusionFixes
         [HarmonyPatch(typeof(Studio.GuideObject), nameof(Studio.GuideObject.CalcRotation))]
         private static void GuideObjectCalcRotationPrefix(Studio.GuideObject __instance)
         {
-            if( !__instance.m_Enables[1] && __instance.transformTarget != null && __instance.mode == GuideObject.Mode.LocalIK )
+            if( __instance.mode == GuideObject.Mode.LocalIK && !__instance.m_Enables[1] && __instance.transformTarget != null )
             {
                 //Initialize rotation so that IKs with disabled rotation follow the parent's rotation
                 __instance.transformTarget.localRotation = Quaternion.identity;


### PR DESCRIPTION
Fixed a bug where the IK rotation state was fixed to that of when the scene was loaded.
This seems to be IK-specific behavior that doesn't rotate.
If it looks OK, please merge.

Maybe this #16

Before:
![guide_before2](https://github.com/IllusionMods/IllusionFixes/assets/4230203/4aa0fce5-69ad-415c-8e95-25c2f2698ef5)

After:
![guide_after2](https://github.com/IllusionMods/IllusionFixes/assets/4230203/5b1ed5e5-195c-4caf-9db7-c5c29a6d0c56)

![2024_0223_0156_51_599](https://github.com/IllusionMods/IllusionFixes/assets/4230203/6ab40b97-f404-4f06-ad23-da071516a27f)
