### PR TITLE
[FE] Fixed eyebrows sometimes being rendered multiple times in one frame

### DIFF
--- a/src/Core_Fix_Eyebrows/EyebrowFix.cs
+++ b/src/Core_Fix_Eyebrows/EyebrowFix.cs
@@ -28,6 +28,8 @@ namespace IllusionFixes
 
         public static ConfigEntry<bool> ConfigEnabled { get; private set; }
 
+        internal static bool inCapture { get; private set; }
+
         internal void Awake()
         {
             ConfigEnabled = Config.Bind("", "Enabled", false, "Whether the plugin is enabled. Restart the game after changing this setting.\n\nWarning: This plugin is still experiemental and not recommended for general use.");
@@ -82,13 +84,21 @@ namespace IllusionFixes
             {
                 rx = Screencap.ScreenshotManager.ResolutionX.Value * Screencap.ScreenshotManager.DownscalingRate.Value;
                 ry = Screencap.ScreenshotManager.ResolutionY.Value * Screencap.ScreenshotManager.DownscalingRate.Value;
+                inCapture = true;
             }
             else
             {
                 rx = Screen.width;
                 ry = Screen.height;
+                inCapture = false;
             }
+
             rt = RenderTexture.GetTemporary(rx, ry, 0, RenderTextureFormat.ARGBHalf);
+            ClearRT();
+        }
+
+        static internal void ClearRT()
+        {
             var rta = RenderTexture.active;
             RenderTexture.active = rt;
             GL.Clear(true, true, Color.clear);
@@ -221,7 +231,14 @@ namespace IllusionFixes
         {
             if (EyebrowFix.rt == null)
                 return;
+
             Graphics.Blit(EyebrowFix.rt, source, EyebrowFix.mat); //blit into whatever the camera sees before applying first post effect (which is apparently ACE)
+
+            if( EyebrowFix.inCapture )
+            {
+                //Clear to avoid drawing multiply when additional drawing flows occur.
+                EyebrowFix.ClearRT();
+            }
         }
 
         /// <summary>

--- a/src/Core_Fix_Eyebrows/EyebrowFix.cs
+++ b/src/Core_Fix_Eyebrows/EyebrowFix.cs
@@ -108,7 +108,7 @@ namespace IllusionFixes
             RenderTexture.active = rta;
         }
 
-        void OnDestroy()
+        private void OnDestroy()
         {
             Camera.onPreCull -= OnPreCull;
         }


### PR DESCRIPTION
Fixed a bug where previous eyebrows remained in the buffer when rendering from multiple cameras during one frame.
Please merge if it looks okay.

Under normal circumstances, the problem does not occur because the same thing is just rendered over and over again.
If the aspect ratio of the screenshot and the aspect ratio of the screen are different, each will be rendered and multiple eyebrows will be drawn on the screenshot.
![image](https://github.com/IllusionMods/IllusionFixes/assets/4230203/e3ce46ed-1602-415e-92e9-b493319f7bdf)


before screen:
![image](https://github.com/IllusionMods/IllusionFixes/assets/4230203/363dcef3-1398-4d7b-ac72-752cacc7f453)

before capture:
![CharaStudio-2024-03-06-11-33-16-Render](https://github.com/IllusionMods/IllusionFixes/assets/4230203/551f9bc6-e14c-465d-8b79-e88a3eabac70)

after capture:
![CharaStudio-2024-03-06-11-36-43-Render](https://github.com/IllusionMods/IllusionFixes/assets/4230203/cd49c3f8-9f0e-4a06-9592-b0045bc71c21)
