### PR TITLE
[HeterochromiaFix] Fixed null reference exception

### DIFF
--- a/src/Core_Fix_Heterochromia/Core.HeterochromiaFix.Hooks.cs
+++ b/src/Core_Fix_Heterochromia/Core.HeterochromiaFix.Hooks.cs
@@ -17,7 +17,7 @@ namespace IllusionFixes
             internal static void LoadFileLimitedPostfix(ChaFileControl __instance)
             {
                 //Find the toggle set
-                var cvsEye02 = CustomBase.Instance.gameObject.GetComponentInChildren<CvsEye02>(true);
+                var cvsEye02 = CustomBase.Instance?.gameObject.GetComponentInChildren<CvsEye02>(true);
                 if (cvsEye02 == null) return;
 
                 var toggles = cvsEye02.tglEyeSetType;

--- a/src/Core_Fix_Heterochromia/Core.HeterochromiaFix.Hooks.cs
+++ b/src/Core_Fix_Heterochromia/Core.HeterochromiaFix.Hooks.cs
@@ -16,8 +16,12 @@ namespace IllusionFixes
 #endif
             internal static void LoadFileLimitedPostfix(ChaFileControl __instance)
             {
+                var customBase = CustomBase.Instance;
+                if (customBase == null)
+                    return;
+
                 //Find the toggle set
-                var cvsEye02 = CustomBase.Instance?.gameObject.GetComponentInChildren<CvsEye02>(true);
+                var cvsEye02 = customBase.GetComponentInChildren<CvsEye02>(true);
                 if (cvsEye02 == null) return;
 
                 var toggles = cvsEye02.tglEyeSetType;


### PR DESCRIPTION
Fixed an exception when calling LoadFile in FreeH.

It will not reproduce if I do not have the plugin in my local environment. However, the fix itself is not a major disadvantage, and it is a good preparation for future changes.

```
NullReferenceException: Object reference not set to an instance of an object
  at IllusionFixes.HeterochromiaFix+Hooks.LoadFileLimitedPostfix (ChaFileControl __instance) [0x00005] in <287529fa9f6743858ecfbc9651184bcf>:0 
  at (wrapper dynamic-method) ChaFileControl.DMD<ChaFileControl::LoadFileLimited>(ChaFileControl,string,byte,bool,bool,bool,bool,bool,bool)
  at MyPlugin.GUIWindow (System.Int32 id) [0x00075] in <71b9c1e39de54c5eb4bcd67924955bfc>:0 
  at UnityEngine.GUILayout+LayoutedWindow.DoWindow (System.Int32 windowID) [0x00070] in <a0bccd5fb00b424ba4b8f758e660f824>:0 
  at UnityEngine.GUI.CallWindowDelegate (UnityEngine.GUI+WindowFunction func, System.Int32 id, System.Int32 instanceID, UnityEngine.GUISkin _skin, System.Int32 forceRect, System.Single width, System.Single height, UnityEngine.GUIStyle style) [0x00078] in <a0bccd5fb00b424ba4b8f758e660f824>:0 
```