### PR TITLE
[FE]Fixed a problem with eyebrows remaining when the character is hidden

### DIFF
--- a/src/Core_Fix_Eyebrows/EyebrowFix.cs
+++ b/src/Core_Fix_Eyebrows/EyebrowFix.cs
@@ -286,6 +286,11 @@ namespace IllusionFixes
             mainCam = Camera.main;
         }
 
+        private void OnDisable()
+        {
+            OnDestroy();
+        }
+
         private void LateUpdate()
         {
             //Track the original state of the renderer (MaterialEditor compatibility)


### PR DESCRIPTION
Maybe it's just my environment, but there was a bug where only the eyebrows remained when the character was hidden.
It seems that there was no post-processing when the object was hidden, so we added it.

https://github.com/IllusionMods/IllusionFixes/assets/32182799/e8826f71-6ef4-4d32-b3bf-cada8e88bf3d

P.S.
I am new to PR so I apologize if anything is incomplete.
I'm glad if I could contribute to the community.