### PR TITLE
[KKS][MainGameOptimizations] Avoid error when saving more than 2 GB in the main game

### DIFF
--- a/src/KKS_Fix_MainGameOptimizations/FixWorldData.cs
+++ b/src/KKS_Fix_MainGameOptimizations/FixWorldData.cs
@@ -1,0 +1,94 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+using System.IO;
+using MessagePack;
+using SaveData;
+
+
+namespace IllusionFixes
+{
+    /// <summary>
+    /// Fix to allow saving when the number of characters and their costumes is large and the total saved data exceeds 2 GB.
+    /// </summary>
+    public partial class MainGameOptimizations
+    {
+        static bool _inWorldSaveHooks = false;
+
+        [HarmonyPatch(typeof(SaveData.WorldData), nameof(SaveData.WorldData.Save), typeof(string), typeof(string))]
+        [HarmonyPrefix]
+        [HarmonyPriority(Priority.Last)]
+        static bool WorldDataSavePrefix( SaveData.WorldData __instance, string path, string fileName)
+        {
+            _inWorldSaveHooks = true;
+
+            try
+            {
+                Illusion.Utils.File.OpenWrite(path + fileName, false, (Action<FileStream>)(f =>
+                {
+                    using (BinaryWriter binaryWriter = new BinaryWriter((Stream)f))
+                    {
+                        var saveData = __instance;
+
+                        // Data to be written by WorldData.GetBytes
+                        byte[] buffer = MessagePackSerializer.Serialize<WorldData>(saveData);
+                        binaryWriter.Write(buffer.Length);
+                        binaryWriter.Write(buffer);
+                        byte[] bytes1 = SaveData.Player.GetBytes(saveData.player);
+                        binaryWriter.Write(bytes1.Length);
+                        binaryWriter.Write(bytes1);
+                        int count = saveData.heroineList.Count;
+                        binaryWriter.Write(count);
+                        for (int index = 0; index < count; ++index)
+                        {
+                            byte[] bytes2 = Heroine.GetBytes(saveData.heroineList[index]);
+                            binaryWriter.Write(bytes2.Length);
+                            binaryWriter.Write(bytes2);
+                        }
+
+                        // Data added by hooks behind normal save data. 
+                        // Normal data is erased by WorldDataGetBytesPrefix and only the data to be added is stored.
+                        var extensionData = SaveData.WorldData.GetBytes(saveData);
+                        binaryWriter.Write(extensionData);                        
+                    }
+                        
+                }));
+
+                return false;
+            }
+            catch( System.Exception e )
+            {
+                UnityEngine.Debug.LogException(e);
+                return true;
+            }
+            finally
+            {
+                _inWorldSaveHooks = false;
+            }
+        }
+
+        /// <summary>
+        /// Function assuming the following hooks to WorldData.GetBytes() in BepisPlugins
+        /// https://github.com/IllusionMods/BepisPlugins/blob/abee07b2392e9d7db88a7f80e68230cf9a7268a8/src/KKS_ExtensibleSaveFormat/KKS.ExtendedSave.SaveData.Hooks.cs#L61
+        /// </summary>
+        [HarmonyPatch(typeof(SaveData.WorldData), nameof(SaveData.WorldData.GetBytes), typeof(SaveData.WorldData))]
+        [HarmonyPrefix]
+        [HarmonyPriority(Priority.VeryHigh)]
+        private static bool WorldDataGetBytesPrefix(SaveData.WorldData saveData, ref byte[] __result)
+        {
+            if ( _inWorldSaveHooks )
+            {
+                __result = new byte[0];
+                return false;
+            }
+            else
+            {
+                return true;
+            }
+        }
+    }
+}

--- a/src/KKS_Fix_MainGameOptimizations/KKS_Fix_MainGameOptimizations.csproj
+++ b/src/KKS_Fix_MainGameOptimizations/KKS_Fix_MainGameOptimizations.csproj
@@ -122,6 +122,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FixWorldData.cs" />
     <Compile Include="MainGameOptimizations.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/KKS_Fix_MainGameOptimizations/MainGameOptimizations.cs
+++ b/src/KKS_Fix_MainGameOptimizations/MainGameOptimizations.cs
@@ -20,7 +20,7 @@ namespace IllusionFixes
     //[BepInProcess(Constants.GameProcessNameSteam)]
     [BepInPlugin(GUID, PluginName, Constants.PluginsVersion)]
     [DefaultExecutionOrder(-1000)]
-    public class MainGameOptimizations : BaseUnityPlugin
+    public partial class MainGameOptimizations : BaseUnityPlugin
     {
         public const string GUID = "KKS_Fix_MainGameOptimizations";
         public const string PluginName = "Main Game Optimizations";
@@ -44,7 +44,7 @@ namespace IllusionFixes
             ThrottleDynamicBoneUpdatesRange.SettingChanged += (sender, args) => UpdateThrottleDynamicBoneUpdatesRange();
             ThrottleDynamicBoneUpdatesViewport = Config.Bind(Utilities.ConfigSectionTweaks, "Pause dynamic bones outside camera view", false, new ConfigDescription("Stops dynamic bone physics in roaming mode for characters that are outside of the camera view (e.g. behind or to the side). Improves performance, but can cause the bones to visibly jerk into place as camera rotates to show the character.\nNeeds 'Throttle dynamic bone updates' to be enabled."));
 
-            Harmony.CreateAndPatchAll(typeof(MainGameOptimizations));
+            Harmony.CreateAndPatchAll(typeof(MainGameOptimizations), GUID);
 
             SceneManager.sceneLoaded += (arg0, mode) =>
             {


### PR DESCRIPTION
When saving saved data in the main game, there was a problem with not being able to save the data when there were many characters and the size exceeded 2 GB. If it looks good, merge it.

If the maximum number of characters is set and the number of costumes is increased continuously, 2 GB is reached.
Fixed to bypass the process via MemoryStream and write directly to the file.

This problem only occurs with KKS.
KK does not go through MemoryStream.

This modification was made at the request of a commission from BitMagnet.