### PR TITLE
DynamicBone AppendParticles fix null ref

### DIFF
--- a/src/Core_Fix_DynamicBones/Core.DynamicBonesFix.cs
+++ b/src/Core_Fix_DynamicBones/Core.DynamicBonesFix.cs
@@ -80,6 +80,7 @@ namespace IllusionFixes
 
                 int count = dynamicBone.m_Particles.Count;
                 dynamicBone.m_Particles.Add(particle);
+                if (!bone) return;
                 while (bone.childCount > 0)
                 {
                     var isNotRoll = false;


### PR DESCRIPTION
Fixed that the the recursion did not end after adding the "leaf" particle, causing it to add another "leaf" particle, which would result in a null reference exception.