### PR TITLE
Fix_DynamicBones - Fix another recursion error

### DIFF
--- a/src/Core_Fix_DynamicBones/Core.DynamicBonesFix.cs
+++ b/src/Core_Fix_DynamicBones/Core.DynamicBonesFix.cs
@@ -101,7 +101,11 @@ namespace IllusionFixes
                         }
 
                         // if child is valid particle, append it as new particle
-                        if (!notValid) AppendParticles(child, count, boneLength, dynamicBone);
+                        if (!notValid)
+                        {
+                            AppendParticles(child, count, boneLength, dynamicBone);
+                            return;
+                        }
                     }
 
                     // we only end up here if all children were in m_Excludes or at least one child was in m_notRolls

--- a/src/Core_Fix_DynamicBones/Core.DynamicBonesFix.cs
+++ b/src/Core_Fix_DynamicBones/Core.DynamicBonesFix.cs
@@ -80,6 +80,7 @@ namespace IllusionFixes
 
                 int count = dynamicBone.m_Particles.Count;
                 dynamicBone.m_Particles.Add(particle);
+                if (!bone) return;
                 while (bone.childCount > 0)
                 {
                     var isNotRoll = false;


### PR DESCRIPTION
_Recursion is hard._ 
After appending a particle, and doing the cursive call on its child, every normal particle would continue to add a leaf particle (obvious in hindsight).
The original game code did not have this issue, even though it also did not return after the recursion call, because it only adds a leaf when the transform associated with the particle has zero children. That, however, is also undesirable since it will not add a leaf particle if the bone chain ends prematurely.
