### PR TITLE
Fix_DynamicBones - Fix append particles recursion error

### DIFF
--- a/src/Core_Fix_DynamicBones/Core.DynamicBonesFix.cs
+++ b/src/Core_Fix_DynamicBones/Core.DynamicBonesFix.cs
@@ -101,7 +101,11 @@ namespace IllusionFixes
                         }
 
                         // if child is valid particle, append it as new particle
-                        if (!notValid) AppendParticles(child, count, boneLength, dynamicBone);
+                        if (!notValid)
+                        {
+                            AppendParticles(child, count, boneLength, dynamicBone);
+                            return;
+                        }
                     }
 
                     // we only end up here if all children were in m_Excludes or at least one child was in m_notRolls

--- a/src/Core_Fix_DynamicBones/Core.DynamicBonesFix.cs
+++ b/src/Core_Fix_DynamicBones/Core.DynamicBonesFix.cs
@@ -81,11 +81,13 @@ namespace IllusionFixes
                 int count = dynamicBone.m_Particles.Count;
                 dynamicBone.m_Particles.Add(particle);
                 if (!bone) return;
-                while (bone.childCount > 0)
+                
+                bool didAppendChildren = false;
+                while (bone.childCount > 0) // used to traverse down children of children
                 {
                     var isNotRoll = false;
                     var index = 0;
-                    for (var i = 0; i < bone.childCount; i++)
+                    for (var i = 0; i < bone.childCount; i++) // used to loop siblings in children
                     {
                         Transform child = bone.GetChild(i);
                         var notValid = false;
@@ -104,18 +106,18 @@ namespace IllusionFixes
                         if (!notValid)
                         {
                             AppendParticles(child, count, boneLength, dynamicBone);
-                            return;
+                            didAppendChildren = true;
                         }
                     }
-
+                    
                     // we only end up here if all children were in m_Excludes or at least one child was in m_notRolls
                     if (isNotRoll) bone = bone.GetChild(index);
                     else break;
                 }
                 
-                // we only end up here if we have broken out of the loop:
-                // A) because the bone doesn't have any children or B) m_Excludes contains all children
-                if (dynamicBone.m_EndLength > 0f || dynamicBone.m_EndOffset != Vector3.zero)
+                // Only add a leaf particle if this particle did not append any of its children:
+                // A) It does not have children or B) all children are part of m_Exclusions
+                if (!didAppendChildren && (dynamicBone.m_EndLength > 0f || dynamicBone.m_EndOffset != Vector3.zero))
                 {
                     // add the final "leaf" particle, based on the EndOffset
                     AppendParticles(null, count, boneLength, dynamicBone);

--- a/src/Core_Fix_DynamicBones/Core.DynamicBonesFix.cs
+++ b/src/Core_Fix_DynamicBones/Core.DynamicBonesFix.cs
@@ -80,6 +80,7 @@ namespace IllusionFixes
 
                 int count = dynamicBone.m_Particles.Count;
                 dynamicBone.m_Particles.Add(particle);
+                if (!bone) return;
                 while (bone.childCount > 0)
                 {
                     var isNotRoll = false;


### PR DESCRIPTION
The return I implemented yesterday would obviously also stop the for loop form adding multiple children like the vanilla code can.
Inspired by the game code, which made adding the leaf require the particle to not have any children, I added a flag so that it can only add a leaf when particle did not add any of its children as particles. This is more similar to game code but also retains the ability to add a leaf particle when all children are in m_Exclusions. 