### PR TITLE
Unify package references into build props; Fix PostBuildEvent

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,16 +15,58 @@
 		<FileAlignment>512</FileAlignment>
 	</PropertyGroup>
 
+	<ItemGroup Condition="'$(Configuration)' == 'Debug'">
+		<PackageReference Include="BepInEx.Analyzers" Version="1.*" />
+		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.*" />
+	</ItemGroup>
+
 	<PropertyGroup Condition=" '$(MSBuildProjectName)' != 'Common' ">
 		<!--Add constants based on the first part of the project name e.g. KK-KKS_Fix_DynamicBones -> KK;KKS-->
 		<DefineConstants>$(MSBuildProjectName.Substring(0, $(MSBuildProjectName.IndexOf('_'))).Replace('-',';'))</DefineConstants>
 	</PropertyGroup>
 
-	<!-- TODO implement dynamically using same method as DefineConstants above
-	<PostBuildEvent>copy "$(TargetPath)" "$(TargetDir)\HS2_Fix_DynamicBones.dll"
-		IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" $(TargetPath) AI
-		IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" "$(TargetDir)HS2_Fix_DynamicBones.dll" HS2</PostBuildEvent>
-	</PropertyGroup>-->
+	<!--Add common nuget packages based on the project name. Must use regex in this way to avoid KK matching KKS, HS matching HS2, etc.-->
+	<ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(';$(DefineConstants);', ';PC;'))">
+		<PackageReference Include="IllusionLibs.BepInEx" Version="5.*" />
+	</ItemGroup>
+	<ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(';$(DefineConstants);', ';SBPR;'))">
+		<PackageReference Include="IllusionLibs.SexyBeachPR.AllPackages" Version="*" />
+	</ItemGroup>
+	<ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(';$(DefineConstants);', ';PH;'))">
+		<PackageReference Include="ExtensibleSaveFormat.PlayHome" Version="21.0" />
+		<PackageReference Include="IllusionLibs.PlayHome.AllPackages" Version="*" />
+	</ItemGroup>
+	<ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(';$(DefineConstants);', ';HS;'))">
+		<PackageReference Include="IllusionLibs.HoneySelect.AllPackages" Version="*" />
+	</ItemGroup>
+	<ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(';$(DefineConstants);', ';AI;'))">
+		<PackageReference Include="ExtensibleSaveFormat.AIGirl" Version="21.0" />
+		<PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
+	</ItemGroup>
+	<ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(';$(DefineConstants);', ';HS2;'))">
+		<PackageReference Include="ExtensibleSaveFormat.HoneySelect2" Version="21.0" />
+		<PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
+	</ItemGroup>
+	<ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(';$(DefineConstants);', ';EC;'))">
+		<PackageReference Include="ExtensibleSaveFormat.EmotionCreators" Version="21.0" />
+		<PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
+	</ItemGroup>
+	<ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(';$(DefineConstants);', ';KK;'))">
+		<PackageReference Include="ExtensibleSaveFormat.Koikatu" Version="21.0" />
+		<PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
+		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="*" />
+	</ItemGroup>
+	<ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(';$(DefineConstants);', ';KKS;'))">
+		<PackageReference Include="ExtensibleSaveFormat.KoikatsuSunshine" Version="21.0" />
+		<PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
+	</ItemGroup>
+
+	<PropertyGroup>
+		<PostBuildEvent Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+			IF EXIST "$(TargetDir)$(TargetName).pdb" IF EXIST "$(SolutionDir)pdb2mdb.exe" CALL "$(SolutionDir)pdb2mdb.exe" "$(TargetPath)"
+			IF EXIST "$(SolutionDir)PostBuild.bat" CALL "$(SolutionDir)PostBuild.bat" "$(TargetPath)" $(GameType)
+		</PostBuildEvent>
+	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
 		<Optimize>true</Optimize>

--- a/src/AI-HS2_Fix_DynamicBones/AI-HS2_Fix_DynamicBones.csproj
+++ b/src/AI-HS2_Fix_DynamicBones/AI-HS2_Fix_DynamicBones.csproj
@@ -3,16 +3,20 @@
 		<TargetFramework>net46</TargetFramework>
 		<AssemblyName>AI_Fix_DynamicBones</AssemblyName>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
+		<PackageReference Update="ExtensibleSaveFormat.HoneySelect2">
+			<ExcludeAssets>all</ExcludeAssets>
+		</PackageReference>
+		<PackageReference Update="IllusionLibs.HoneySelect2.AllPackages">
+			<ExcludeAssets>all</ExcludeAssets>
+		</PackageReference>
 	</ItemGroup>
+
 	<Target Name="CopyOutputDll" AfterTargets="Build">
 		<Copy SourceFiles="$(TargetPath)" DestinationFiles="$(TargetDir)HS2_Fix_DynamicBones.dll" />
 	</Target>
+
 	<Import Project="..\Core_Fix_DynamicBones\Core_Fix_DynamicBones.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Fix_AssignMainCamera/AI_Fix_AssignMainCamera.csproj
+++ b/src/AI_Fix_AssignMainCamera/AI_Fix_AssignMainCamera.csproj
@@ -2,12 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Fix_CameraTarget/AI_Fix_CameraTarget.csproj
+++ b/src/AI_Fix_CameraTarget/AI_Fix_CameraTarget.csproj
@@ -2,13 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_CameraTarget\Core_Fix_CameraTarget.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Fix_DataCorruptionFixes/AI_Fix_DataCorruptionFixes.csproj
+++ b/src/AI_Fix_DataCorruptionFixes/AI_Fix_DataCorruptionFixes.csproj
@@ -2,13 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.JSONSerializeModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Fix_ExpandShaderDropdown/AI_Fix_ExpandShaderDropdown.csproj
+++ b/src/AI_Fix_ExpandShaderDropdown/AI_Fix_ExpandShaderDropdown.csproj
@@ -2,13 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.UI" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Fix_GarbageTruck/AI_Fix_GarbageTruck.csproj
+++ b/src/AI_Fix_GarbageTruck/AI_Fix_GarbageTruck.csproj
@@ -2,23 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp-firstpass" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.Cinemachine" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.MessagePack" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.Sirenix.Serialization" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UniRx" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.AudioModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.IMGUIModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.PhysicsModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.UI" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.UIModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.36.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Fix_InvalidSceneFileProtection/AI_Fix_InvalidSceneFileProtection.csproj
+++ b/src/AI_Fix_InvalidSceneFileProtection/AI_Fix_InvalidSceneFileProtection.csproj
@@ -2,13 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_InvalidSceneFileProtection\Core_Fix_InvalidSceneFileProtection.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Fix_MakerMaleFaceTypes/AI_Fix_MakerMaleFaceTypes.csproj
+++ b/src/AI_Fix_MakerMaleFaceTypes/AI_Fix_MakerMaleFaceTypes.csproj
@@ -2,22 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.AIGirl" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp-firstpass" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.MessagePack" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.Sirenix.Serialization" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UniRx" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.IMGUIModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.UI" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.UIModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
 		<PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.36.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_MakerMaleFaceTypes\Core_Fix_MakerMaleFaceTypes.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Fix_MakerOptimizations/AI_Fix_MakerOptimizations.csproj
+++ b/src/AI_Fix_MakerOptimizations/AI_Fix_MakerOptimizations.csproj
@@ -2,17 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UniRx" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.IMGUIModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.UI" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.UIModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_MakerOptimizations_CursorManager\Core_Fix_MakerOptimizations_CursorManager.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Fix_ManifestCorrector/AI_Fix_ManifestCorrector.csproj
+++ b/src/AI_Fix_ManifestCorrector/AI_Fix_ManifestCorrector.csproj
@@ -2,13 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_ManifestCorrector\Core_Fix_ManifestCorrector.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Fix_NewGameShowAllCards/AI_Fix_NewGameShowAllCards.csproj
+++ b/src/AI_Fix_NewGameShowAllCards/AI_Fix_NewGameShowAllCards.csproj
@@ -2,12 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Fix_NullChecks/AI_Fix_NullChecks.csproj
+++ b/src/AI_Fix_NullChecks/AI_Fix_NullChecks.csproj
@@ -2,22 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp-firstpass" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.MessagePack" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.Sirenix.Serialization" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UniRx" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.Unity.Postprocessing.Runtime" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.IMGUIModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.UI" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.UIModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
 		<PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.36.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_NullChecks\Core_Fix_NullChecks.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Fix_PoseLoad/AI_Fix_PoseLoad.csproj
+++ b/src/AI_Fix_PoseLoad/AI_Fix_PoseLoad.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.AIGirl" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_PoseLoad\Core_Fix_PoseLoad.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Fix_ResourceUnloadOptimizations/AI_Fix_ResourceUnloadOptimizations.csproj
+++ b/src/AI_Fix_ResourceUnloadOptimizations/AI_Fix_ResourceUnloadOptimizations.csproj
@@ -2,14 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
 		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_ResourceUnloadOptimizations\Core_Fix_ResourceUnloadOptimizations.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Fix_SettingsVerifier/AI_Fix_SettingsVerifier.csproj
+++ b/src/AI_Fix_SettingsVerifier/AI_Fix_SettingsVerifier.csproj
@@ -2,18 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<EmbeddedResource Include="Resources\setup.xml">
-			<SubType>Designer</SubType>
-		</EmbeddedResource>
+		<EmbeddedResource Include="Resources\setup.xml"/>
 	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_SettingsVerifier\Core_Fix_SettingsVerifier.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Fix_StudioOptimizations/AI_Fix_StudioOptimizations.csproj
+++ b/src/AI_Fix_StudioOptimizations/AI_Fix_StudioOptimizations.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.UI" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_StudioOptimizations\Core_Fix_StudioOptimizations.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Fix_WetAccessories/AI_Fix_WetAccessories.csproj
+++ b/src/AI_Fix_WetAccessories/AI_Fix_WetAccessories.csproj
@@ -2,22 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.AIGirl" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.Assembly-CSharp-firstpass" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.MessagePack" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.Sirenix.Serialization" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UniRx" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.IMGUIModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.UI" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.UIModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.36.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_WetAccessories\Core_Fix_WetAccessories.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Patch_LogDespammer/AI_Patch_LogDespammer.csproj
+++ b/src/AI_Patch_LogDespammer/AI_Patch_LogDespammer.csproj
@@ -2,19 +2,12 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 		<RootNamespace>AI_Fixes</RootNamespace>
-	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		<OutputPath>..\..\bin\BepInEx\patchers\</OutputPath>
 	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-		<OutputPath>..\..\bin\BepInEx\patchers\</OutputPath>
-	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
 		<PackageReference Include="IllusionLibs.BepInEx.Mono.Cecil" Version="0.10.4.1" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Patch_SteamReleaseCompatibility/AI_Patch_SteamReleaseCompatibility.csproj
+++ b/src/AI_Patch_SteamReleaseCompatibility/AI_Patch_SteamReleaseCompatibility.csproj
@@ -2,19 +2,12 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 		<RootNamespace>AI_Fixes</RootNamespace>
-	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		<OutputPath>..\..\bin\BepInEx\patchers\</OutputPath>
 	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-		<OutputPath>..\..\bin\BepInEx\patchers\</OutputPath>
-	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.AIGirl.UnityEngine.CoreModule" Version="2018.2.21.4" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
 		<PackageReference Include="IllusionLibs.BepInEx.Mono.Cecil" Version="0.10.4.1" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/AI_Patch_SteamReleaseCompatibility/SteamReleaseCompatibilityPatch.cs
+++ b/src/AI_Patch_SteamReleaseCompatibility/SteamReleaseCompatibilityPatch.cs
@@ -62,7 +62,7 @@ namespace AI_Fixes
                 }
                 else
                 {
-                    Logger.Log(LogLevel.Warning | LogLevel.Message, $"Could not find {mmBaseStu.Name} to fix Studio compatibility, expect bugs!");
+                    Logger.Log(BepInEx.Logging.LogLevel.Warning | BepInEx.Logging.LogLevel.Message, $"Could not find {mmBaseStu.Name} to fix Studio compatibility, expect bugs!");
                 }
 
                 var ooBaseStu = new FileInfo(Path.Combine(Paths.GameRootPath, @"abdata\chara\oo_base_studio.unity3d"));
@@ -73,7 +73,7 @@ namespace AI_Fixes
                 }
                 else
                 {
-                    Logger.Log(LogLevel.Warning | LogLevel.Message, $"Could not find {ooBaseStu.Name} to fix Studio compatibility, expect bugs!");
+                    Logger.Log(BepInEx.Logging.LogLevel.Warning | BepInEx.Logging.LogLevel.Message, $"Could not find {ooBaseStu.Name} to fix Studio compatibility, expect bugs!");
                 }
             }
             else
@@ -90,7 +90,7 @@ namespace AI_Fixes
 
             if (!File.Exists(studioAssPath))
             {
-                Logger.Log(LogLevel.Warning | LogLevel.Message, "Cannot apply compatibility patches because studio is not installed. Expect plugin crashes!");
+                Logger.Log(BepInEx.Logging.LogLevel.Warning | BepInEx.Logging.LogLevel.Message, "Cannot apply compatibility patches because studio is not installed. Expect plugin crashes!");
                 return;
             }
 

--- a/src/EC_Fix_CameraMaskResize/EC_Fix_CameraMaskResize.csproj
+++ b/src/EC_Fix_CameraMaskResize/EC_Fix_CameraMaskResize.csproj
@@ -2,13 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" Version="2017.4.24.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_CameraMaskResize\Core_Fix_CameraMaskResize.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/EC_Fix_CardImport/EC_Fix_CardImport.csproj
+++ b/src/EC_Fix_CardImport/EC_Fix_CardImport.csproj
@@ -2,12 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" Version="2017.4.24.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/EC_Fix_DownloadRenamer/EC_Fix_DownloadRenamer.csproj
+++ b/src/EC_Fix_DownloadRenamer/EC_Fix_DownloadRenamer.csproj
@@ -2,13 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.IL" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" Version="2017.4.24.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/EC_Fix_DynamicBones/EC_Fix_DynamicBones.csproj
+++ b/src/EC_Fix_DynamicBones/EC_Fix_DynamicBones.csproj
@@ -2,13 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" Version="2017.4.24.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_DynamicBones\Core_Fix_DynamicBones.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/EC_Fix_ExpandShaderDropdown/EC_Fix_ExpandShaderDropdown.csproj
+++ b/src/EC_Fix_ExpandShaderDropdown/EC_Fix_ExpandShaderDropdown.csproj
@@ -2,15 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.IL" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.TextMeshPro" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" Version="2017.4.24.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.UI" Version="2017.4.24.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/EC_Fix_GuideObjects/EC_Fix_GuideObjects.csproj
+++ b/src/EC_Fix_GuideObjects/EC_Fix_GuideObjects.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.IL" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" Version="2017.4.24.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_GuideObjects\Core_Fix_GuideObjects.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/EC_Fix_HairShadows/EC_Fix_HairShadows.csproj
+++ b/src/EC_Fix_HairShadows/EC_Fix_HairShadows.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.IL" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" Version="2017.4.24.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_HairShadows\Core_Fix_HairShadows.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/EC_Fix_Heterochromia/EC_Fix_Heterochromia.csproj
+++ b/src/EC_Fix_Heterochromia/EC_Fix_Heterochromia.csproj
@@ -2,15 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.IL" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" Version="2017.4.24.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.UI" Version="2017.4.24.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_Heterochromia\Core_Fix_Heterochromia.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/EC_Fix_MakerOptimizations/EC_Fix_MakerOptimizations.csproj
+++ b/src/EC_Fix_MakerOptimizations/EC_Fix_MakerOptimizations.csproj
@@ -2,19 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp-firstpass" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.IL" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UniRx" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" Version="2017.4.24.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.IMGUIModule" Version="2017.4.24.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.UI" Version="2017.4.24.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.UIModule" Version="2017.4.24.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_MakerOptimizations_CursorManager\Core_Fix_MakerOptimizations_CursorManager.projitems" Label="Shared" />
 	<Import Project="..\Core_Fix_MakerOptimizations\Core_Fix_MakerOptimizations.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />

--- a/src/EC_Fix_ManifestCorrector/EC_Fix_ManifestCorrector.csproj
+++ b/src/EC_Fix_ManifestCorrector/EC_Fix_ManifestCorrector.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.IL" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" Version="2017.4.24.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_ManifestCorrector\Core_Fix_ManifestCorrector.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/EC_Fix_ModdedHeadEyeliner/EC_Fix_ModdedHeadEyeliner.csproj
+++ b/src/EC_Fix_ModdedHeadEyeliner/EC_Fix_ModdedHeadEyeliner.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.IL" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" Version="2017.4.24.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_ModdedHeadEyeliner\Core_Fix_ModdedHeadEyeliner.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/EC_Fix_NodeUnlock/EC_Fix_NodeUnlock.csproj
+++ b/src/EC_Fix_NodeUnlock/EC_Fix_NodeUnlock.csproj
@@ -2,13 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UniRx" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" Version="2017.4.24.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/EC_Fix_NullChecks/EC_Fix_NullChecks.csproj
+++ b/src/EC_Fix_NullChecks/EC_Fix_NullChecks.csproj
@@ -2,20 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp-firstpass" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.IL" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UniRx" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" Version="2017.4.24.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.IMGUIModule" Version="2017.4.24.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.UI" Version="2017.4.24.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.UIModule" Version="2017.4.24.4" />
 		<PackageReference Include="IllusionModdingAPI.ECAPI" Version="1.36.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_NullChecks\Core_Fix_NullChecks.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/EC_Fix_PartyCardCompatibility/EC_Fix_PartyCardCompatibility.csproj
+++ b/src/EC_Fix_PartyCardCompatibility/EC_Fix_PartyCardCompatibility.csproj
@@ -2,12 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" Version="2017.4.24.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/EC_Fix_ResourceUnloadOptimizations/EC_Fix_ResourceUnloadOptimizations.csproj
+++ b/src/EC_Fix_ResourceUnloadOptimizations/EC_Fix_ResourceUnloadOptimizations.csproj
@@ -2,15 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
 		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.IL" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" Version="2017.4.24.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_ResourceUnloadOptimizations\Core_Fix_ResourceUnloadOptimizations.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/EC_Fix_SettingsVerifier/EC_Fix_SettingsVerifier.csproj
+++ b/src/EC_Fix_SettingsVerifier/EC_Fix_SettingsVerifier.csproj
@@ -2,17 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
 		<EmbeddedResource Include="Resources\setup.xml" />
 	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.Assembly-CSharp" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.IL" Version="2019.6.6.4" />
-		<PackageReference Include="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" Version="2017.4.24.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_SettingsVerifier\Core_Fix_SettingsVerifier.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS2_Fix_CameraTarget/HS2_Fix_CameraTarget.csproj
+++ b/src/HS2_Fix_CameraTarget/HS2_Fix_CameraTarget.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.IL" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" Version="2018.4.11.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_CameraTarget\Core_Fix_CameraTarget.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS2_Fix_DataCorruptionFixes/HS2_Fix_DataCorruptionFixes.csproj
+++ b/src/HS2_Fix_DataCorruptionFixes/HS2_Fix_DataCorruptionFixes.csproj
@@ -2,14 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.IL" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.JSONSerializeModule" Version="2018.4.11.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS2_Fix_ExpandShaderDropdown/HS2_Fix_ExpandShaderDropdown.csproj
+++ b/src/HS2_Fix_ExpandShaderDropdown/HS2_Fix_ExpandShaderDropdown.csproj
@@ -2,14 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.IL" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.UI" Version="2018.4.11.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS2_Fix_GarbageTruck/HS2_Fix_GarbageTruck.csproj
+++ b/src/HS2_Fix_GarbageTruck/HS2_Fix_GarbageTruck.csproj
@@ -2,24 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Cinemachine" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.IL" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Sirenix.Serialization" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UniRx" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.AudioModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.PhysicsModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.UI" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.UIModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionModdingAPI.HS2API" Version="1.36.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-		<PackageReference Include="ScreenshotManager.HoneySelect2" Version="19.3.3" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS2_Fix_GravityAdjust/HS2_Fix_GravityAdjust.csproj
+++ b/src/HS2_Fix_GravityAdjust/HS2_Fix_GravityAdjust.csproj
@@ -2,12 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.PhysicsModule" Version="2018.4.11.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS2_Fix_InvalidSceneFileProtection/HS2_Fix_InvalidSceneFileProtection.csproj
+++ b/src/HS2_Fix_InvalidSceneFileProtection/HS2_Fix_InvalidSceneFileProtection.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.IL" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" Version="2018.4.11.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_InvalidSceneFileProtection\Core_Fix_InvalidSceneFileProtection.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS2_Fix_MakerMaleFaceTypes/HS2_Fix_MakerMaleFaceTypes.csproj
+++ b/src/HS2_Fix_MakerMaleFaceTypes/HS2_Fix_MakerMaleFaceTypes.csproj
@@ -2,22 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.HoneySelect2" Version="19.4.0" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.IL" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Sirenix.Serialization" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UniRx" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.UI" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.UIModule" Version="2018.4.11.4" />
 		<PackageReference Include="IllusionModdingAPI.HS2API" Version="1.36.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_MakerMaleFaceTypes\Core_Fix_MakerMaleFaceTypes.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS2_Fix_MakerOptimizations/HS2_Fix_MakerOptimizations.csproj
+++ b/src/HS2_Fix_MakerOptimizations/HS2_Fix_MakerOptimizations.csproj
@@ -2,17 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.IL" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.UI" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.UIModule" Version="2018.4.11.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_MakerOptimizations_CursorManager\Core_Fix_MakerOptimizations_CursorManager.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS2_Fix_ManifestCorrector/HS2_Fix_ManifestCorrector.csproj
+++ b/src/HS2_Fix_ManifestCorrector/HS2_Fix_ManifestCorrector.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.IL" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" Version="2018.4.11.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_ManifestCorrector\Core_Fix_ManifestCorrector.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS2_Fix_NullChecks/HS2_Fix_NullChecks.csproj
+++ b/src/HS2_Fix_NullChecks/HS2_Fix_NullChecks.csproj
@@ -2,22 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.IL" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Sirenix.Serialization" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UniRx" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Unity.Postprocessing.Runtime" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.UI" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.UIModule" Version="2018.4.11.4" />
 		<PackageReference Include="IllusionModdingAPI.HS2API" Version="1.36.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_NullChecks\Core_Fix_NullChecks.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS2_Fix_PersonalityCorrector/HS2_Fix_PersonalityCorrector.csproj
+++ b/src/HS2_Fix_PersonalityCorrector/HS2_Fix_PersonalityCorrector.csproj
@@ -2,20 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.IL" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Sirenix.Serialization" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UniRx" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.UI" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.UIModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionModdingAPI.HS2API" Version="1.36.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS2_Fix_PoseLoad/HS2_Fix_PoseLoad.csproj
+++ b/src/HS2_Fix_PoseLoad/HS2_Fix_PoseLoad.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.HoneySelect2" Version="19.4.0" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" Version="2018.4.11.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_PoseLoad\Core_Fix_PoseLoad.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS2_Fix_ResourceUnloadOptimizations/HS2_Fix_ResourceUnloadOptimizations.csproj
+++ b/src/HS2_Fix_ResourceUnloadOptimizations/HS2_Fix_ResourceUnloadOptimizations.csproj
@@ -2,15 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
 		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.IL" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" Version="2018.4.11.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_ResourceUnloadOptimizations\Core_Fix_ResourceUnloadOptimizations.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS2_Fix_SettingsVerifier/HS2_Fix_SettingsVerifier.csproj
+++ b/src/HS2_Fix_SettingsVerifier/HS2_Fix_SettingsVerifier.csproj
@@ -2,19 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<EmbeddedResource Include="Resources\setup.xml">
-			<SubType>Designer</SubType>
-		</EmbeddedResource>
+		<EmbeddedResource Include="Resources\setup.xml"/>
 	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.IL" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" Version="2018.4.11.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_SettingsVerifier\Core_Fix_SettingsVerifier.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS2_Fix_StudioOptimizations/HS2_Fix_StudioOptimizations.csproj
+++ b/src/HS2_Fix_StudioOptimizations/HS2_Fix_StudioOptimizations.csproj
@@ -2,15 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.IL" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.UI" Version="2018.4.11.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_StudioOptimizations\Core_Fix_StudioOptimizations.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS2_Fix_UpdateWet/HS2_Fix_UpdateWet.csproj
+++ b/src/HS2_Fix_UpdateWet/HS2_Fix_UpdateWet.csproj
@@ -2,12 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" Version="2018.4.11.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS2_Fix_WetAccessories/HS2_Fix_WetAccessories.csproj
+++ b/src/HS2_Fix_WetAccessories/HS2_Fix_WetAccessories.csproj
@@ -2,22 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.HoneySelect2" Version="19.4.0" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Assembly-CSharp-firstpass" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.IL" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.Sirenix.Serialization" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UniRx" Version="2020.5.29.5" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.UI" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionLibs.HoneySelect2.UnityEngine.UIModule" Version="2018.4.11.4" />
-		<PackageReference Include="IllusionModdingAPI.HS2API" Version="1.36.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_WetAccessories\Core_Fix_WetAccessories.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/HS_Fix_ResourceUnloadOptimizations/HS_Fix_ResourceUnloadOptimizations.csproj
+++ b/src/HS_Fix_ResourceUnloadOptimizations/HS_Fix_ResourceUnloadOptimizations.csproj
@@ -2,14 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
 		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="IllusionLibs.HoneySelect.Assembly-CSharp" Version="2017.6.30.2" />
-		<PackageReference Include="IllusionLibs.HoneySelect.UnityEngine" Version="5.3.5.2" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_ResourceUnloadOptimizations\Core_Fix_ResourceUnloadOptimizations.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKP_Fix_CharacterListOptimizations/KKP_Fix_CharacterListOptimizations.csproj
+++ b/src/KKP_Fix_CharacterListOptimizations/KKP_Fix_CharacterListOptimizations.csproj
@@ -3,15 +3,17 @@
 		<TargetFramework>net35</TargetFramework>
 		<DefineConstants>$(DefineConstants);KK</DefineConstants>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.Koikatu" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
+		<PackageReference Update="KoikatuCompatibilityAnalyzer">
+			<ExcludeAssets>all</ExcludeAssets>
+		</PackageReference>
+		<!-- This is necessary to override the Koikatu dll added by AllPackages with the dll in KoikatsuParty package (dll from AllPackages takes priority by default) -->
+		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.*">
+			<ExcludeAssets>all</ExcludeAssets>
+		</PackageReference>
 		<PackageReference Include="IllusionLibs.KoikatsuParty.Assembly-CSharp" Version="2021.3.25" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp-firstpass" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine.UI" Version="5.6.2.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_CameraMaskResize/KKS_Fix_CameraMaskResize.csproj
+++ b/src/KKS_Fix_CameraMaskResize/KKS_Fix_CameraMaskResize.csproj
@@ -2,16 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.UI" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-		<PackageReference Include="ScreenshotManager.KoikatsuSunshine" Version="19.3.3" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_CameraMaskResize\Core_Fix_CameraMaskResize.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_CameraTarget/KKS_Fix_CameraTarget.csproj
+++ b/src/KKS_Fix_CameraTarget/KKS_Fix_CameraTarget.csproj
@@ -2,13 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_CameraTarget\Core_Fix_CameraTarget.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_CharacterListOptimizations/KKS_Fix_CharacterListOptimizations.csproj
+++ b/src/KKS_Fix_CharacterListOptimizations/KKS_Fix_CharacterListOptimizations.csproj
@@ -2,15 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net462</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.KoikatsuSunshine" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniRx" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.UI" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_DataCorruptionFixes/KKS_Fix_DataCorruptionFixes.csproj
+++ b/src/KKS_Fix_DataCorruptionFixes/KKS_Fix_DataCorruptionFixes.csproj
@@ -2,20 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.KoikatsuSunshine" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniRx" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniTask" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.AnimationModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.InputLegacyModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.PhysicsModule" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_ExpandShaderDropdown/KKS_Fix_ExpandShaderDropdown.csproj
+++ b/src/KKS_Fix_ExpandShaderDropdown/KKS_Fix_ExpandShaderDropdown.csproj
@@ -2,15 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Unity.TextMeshPro" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.UI" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.UIModule" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_Eyebrows/KKS_Fix_Eyebrows.csproj
+++ b/src/KKS_Fix_Eyebrows/KKS_Fix_Eyebrows.csproj
@@ -2,26 +2,12 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.KoikatsuSunshine" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniRx" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniTask" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.AnimationModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.IMGUIModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.InputLegacyModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.PhysicsModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.UI" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.UIModule" Version="2019.4.9" />
 		<PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.36.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 		<PackageReference Include="ScreenshotManager.KoikatsuSunshine" Version="19.3.3" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_Eyebrows\Core_Fix_Eyebrows.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_FaceShadows/KKS_Fix_FaceShadows.csproj
+++ b/src/KKS_Fix_FaceShadows/KKS_Fix_FaceShadows.csproj
@@ -2,12 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_GarbageTruck/KKS_Fix_GarbageTruck.csproj
+++ b/src/KKS_Fix_GarbageTruck/KKS_Fix_GarbageTruck.csproj
@@ -2,24 +2,10 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.KoikatsuSunshine" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniRx" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniTask" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.AnimationModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.AudioModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.IMGUIModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.InputLegacyModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.PhysicsModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.UI" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 		<PackageReference Include="ScreenshotManager.KoikatsuSunshine" Version="19.3.3" />
 	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_GuideObjects/KKS_Fix_GuideObjects.csproj
+++ b/src/KKS_Fix_GuideObjects/KKS_Fix_GuideObjects.csproj
@@ -2,21 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.KoikatsuSunshine" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniRx" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniTask" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.AnimationModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.InputLegacyModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.PhysicsModule" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_GuideObjects\Core_Fix_GuideObjects.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_HairShadows/KKS_Fix_HairShadows.csproj
+++ b/src/KKS_Fix_HairShadows/KKS_Fix_HairShadows.csproj
@@ -2,13 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_HairShadows\Core_Fix_HairShadows.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_Heterochromia/KKS_Fix_Heterochromia.csproj
+++ b/src/KKS_Fix_Heterochromia/KKS_Fix_Heterochromia.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.UI" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_Heterochromia\Core_Fix_Heterochromia.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_LoadFileLimited/KKS_Fix_LoadFileLimited.csproj
+++ b/src/KKS_Fix_LoadFileLimited/KKS_Fix_LoadFileLimited.csproj
@@ -2,12 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_LoadFileLimited\Core_Fix_LoadFileLimited.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_MainGameOptimizations/KKS_Fix_MainGameOptimizations.csproj
+++ b/src/KKS_Fix_MainGameOptimizations/KKS_Fix_MainGameOptimizations.csproj
@@ -2,20 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.KoikatsuSunshine" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniRx" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniTask" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.AnimationModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.InputLegacyModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.PhysicsModule" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_MakerOptimizations/KKS_Fix_MakerOptimizations.csproj
+++ b/src/KKS_Fix_MakerOptimizations/KKS_Fix_MakerOptimizations.csproj
@@ -2,19 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniRx" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.IMGUIModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.InputLegacyModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.UI" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.UIModule" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_MakerOptimizations_CursorManager\Core_Fix_MakerOptimizations_CursorManager.projitems" Label="Shared" />
 	<Import Project="..\Core_Fix_MakerOptimizations\Core_Fix_MakerOptimizations.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />

--- a/src/KKS_Fix_ManifestCorrector/KKS_Fix_ManifestCorrector.csproj
+++ b/src/KKS_Fix_ManifestCorrector/KKS_Fix_ManifestCorrector.csproj
@@ -2,13 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_ManifestCorrector\Core_Fix_ManifestCorrector.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_NullChecks/KKS_Fix_NullChecks.csproj
+++ b/src/KKS_Fix_NullChecks/KKS_Fix_NullChecks.csproj
@@ -2,26 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.KoikatsuSunshine" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniRx" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniTask" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Unity.Postprocessing.Runtime" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.AnimationModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.IMGUIModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.InputLegacyModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.PhysicsModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.UI" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.UIModule" Version="2019.4.9" />
 		<PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.36.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_NullChecks\Core_Fix_NullChecks.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_PersonalityCorrector/KKS_Fix_PersonalityCorrector.csproj
+++ b/src/KKS_Fix_PersonalityCorrector/KKS_Fix_PersonalityCorrector.csproj
@@ -2,22 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.KoikatsuSunshine" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniRx" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniTask" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.IMGUIModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.InputLegacyModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.UI" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.UIModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.36.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 	<Import Project="..\Core_Fix_PersonalityCorrector\Core_Fix_PersonalityCorrector.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_PoseLoad/KKS_Fix_PoseLoad.csproj
+++ b/src/KKS_Fix_PoseLoad/KKS_Fix_PoseLoad.csproj
@@ -2,15 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.KoikatsuSunshine" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.InputLegacyModule" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_PoseLoad\Core_Fix_PoseLoad.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_ResourceUnloadOptimizations/KKS_Fix_ResourceUnloadOptimizations.csproj
+++ b/src/KKS_Fix_ResourceUnloadOptimizations/KKS_Fix_ResourceUnloadOptimizations.csproj
@@ -2,14 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
 		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_ResourceUnloadOptimizations\Core_Fix_ResourceUnloadOptimizations.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_SettingsVerifier/KKS_Fix_SettingsVerifier.csproj
+++ b/src/KKS_Fix_SettingsVerifier/KKS_Fix_SettingsVerifier.csproj
@@ -2,18 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<EmbeddedResource Include="Resources\setup.xml">
-			<SubType>Designer</SubType>
-		</EmbeddedResource>
+		<EmbeddedResource Include="Resources\setup.xml"/>
 	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_SettingsVerifier\Core_Fix_SettingsVerifier.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_ShowerAccessories/KKS_Fix_ShowerAccessories.csproj
+++ b/src/KKS_Fix_ShowerAccessories/KKS_Fix_ShowerAccessories.csproj
@@ -2,22 +2,12 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.KoikatsuSunshine" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
 		<PackageReference Include="IllusionLibs.BepInEx.Mono.Cecil" Version="0.10.4.1" />
 		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniRx" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UniTask" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.AnimationModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.InputLegacyModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.PhysicsModule" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_ShowerAccessories\Core_Fix_ShowerAccessories.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KKS_Fix_StudioOptimizations/KKS_Fix_StudioOptimizations.csproj
+++ b/src/KKS_Fix_StudioOptimizations/KKS_Fix_StudioOptimizations.csproj
@@ -2,15 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.Assembly-CSharp" Version="2021.9.17" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.ClothModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.CoreModule" Version="2019.4.9" />
-		<PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.UI" Version="2019.4.9" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_StudioOptimizations\Core_Fix_StudioOptimizations.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_CameraTarget/KK_Fix_CameraTarget.csproj
+++ b/src/KK_Fix_CameraTarget/KK_Fix_CameraTarget.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_CameraTarget\Core_Fix_CameraTarget.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_CenteredHSceneCursor/KK_Fix_CenteredHSceneCursor.csproj
+++ b/src/KK_Fix_CenteredHSceneCursor/KK_Fix_CenteredHSceneCursor.csproj
@@ -2,13 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_CharacterListOptimizations/KK_Fix_CharacterListOptimizations.csproj
+++ b/src/KK_Fix_CharacterListOptimizations/KK_Fix_CharacterListOptimizations.csproj
@@ -2,16 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.Koikatu" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp-firstpass" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine.UI" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_DataCorruptionFixes/KK_Fix_DataCorruptionFixes.csproj
+++ b/src/KK_Fix_DataCorruptionFixes/KK_Fix_DataCorruptionFixes.csproj
@@ -2,13 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_DynamicBones/KK-KKS_Fix_DynamicBones.csproj
+++ b/src/KK_Fix_DynamicBones/KK-KKS_Fix_DynamicBones.csproj
@@ -3,17 +3,23 @@
 		<TargetFramework>net35</TargetFramework>
 		<AssemblyName>KK_Fix_DynamicBones</AssemblyName>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
+		<PackageReference Update="ExtensibleSaveFormat.KoikatsuSunshine">
+			<ExcludeAssets>all</ExcludeAssets>
+		</PackageReference>
+		<PackageReference Update="ExtensibleSaveFormat.Koikatu">
+			<ExcludeAssets>all</ExcludeAssets>
+		</PackageReference>
+		<PackageReference Update="IllusionLibs.KoikatsuSunshine.AllPackages">
+			<ExcludeAssets>all</ExcludeAssets>
+		</PackageReference>
 	</ItemGroup>
+
 	<Target Name="CopyOutputDll" AfterTargets="Build">
 		<Copy SourceFiles="$(TargetPath)" DestinationFiles="$(TargetDir)KKS_Fix_DynamicBones.dll" />
 	</Target>
+
 	<Import Project="..\Core_Fix_DynamicBones\Core_Fix_DynamicBones.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_ExpandShaderDropdown/KK_Fix_ExpandShaderDropdown.csproj
+++ b/src/KK_Fix_ExpandShaderDropdown/KK_Fix_ExpandShaderDropdown.csproj
@@ -2,15 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.TextMeshPro" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine.UI" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_Eyebrows/KK_Fix_Eyebrows.csproj
+++ b/src/KK_Fix_Eyebrows/KK_Fix_Eyebrows.csproj
@@ -2,20 +2,12 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.Koikatu" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp-firstpass" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine.UI" Version="5.6.2.4" />
 		<PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.36.0" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 		<PackageReference Include="ScreenshotManager.Koikatu" Version="19.3.3" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_Eyebrows\Core_Fix_Eyebrows.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_GarbageTruck/KK_Fix_GarbageTruck.csproj
+++ b/src/KK_Fix_GarbageTruck/KK_Fix_GarbageTruck.csproj
@@ -2,13 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_GuideObjects/KK_Fix_GuideObjects.csproj
+++ b/src/KK_Fix_GuideObjects/KK_Fix_GuideObjects.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_GuideObjects\Core_Fix_GuideObjects.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_HairShadows/KK_Fix_HairShadows.csproj
+++ b/src/KK_Fix_HairShadows/KK_Fix_HairShadows.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_HairShadows\Core_Fix_HairShadows.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_Heterochromia/KK_Fix_Heterochromia.csproj
+++ b/src/KK_Fix_Heterochromia/KK_Fix_Heterochromia.csproj
@@ -2,15 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine.UI" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_Heterochromia\Core_Fix_Heterochromia.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_InvalidSceneFileProtection/KK-KKS_Fix_InvalidSceneFileProtection.csproj
+++ b/src/KK_Fix_InvalidSceneFileProtection/KK-KKS_Fix_InvalidSceneFileProtection.csproj
@@ -3,17 +3,20 @@
 		<TargetFramework>net35</TargetFramework>
 		<AssemblyName>KK_Fix_InvalidSceneFileProtection</AssemblyName>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
+		<PackageReference Update="ExtensibleSaveFormat.KoikatsuSunshine">
+			<ExcludeAssets>all</ExcludeAssets>
+		</PackageReference>
+		<PackageReference Update="IllusionLibs.KoikatsuSunshine.AllPackages">
+			<ExcludeAssets>all</ExcludeAssets>
+		</PackageReference>
 	</ItemGroup>
+
 	<Target Name="CopyOutputDll" AfterTargets="Build">
 		<Copy SourceFiles="$(TargetPath)" DestinationFiles="$(TargetDir)KKS_Fix_InvalidSceneFileProtection.dll" />
 	</Target>
+
 	<Import Project="..\Core_Fix_InvalidSceneFileProtection\Core_Fix_InvalidSceneFileProtection.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_LoadFileLimited/KK_Fix_LoadFileLimited.csproj
+++ b/src/KK_Fix_LoadFileLimited/KK_Fix_LoadFileLimited.csproj
@@ -2,12 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_LoadFileLimited\Core_Fix_LoadFileLimited.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_MainGameOptimizations/KK_Fix_MainGameOptimizations.csproj
+++ b/src/KK_Fix_MainGameOptimizations/KK_Fix_MainGameOptimizations.csproj
@@ -2,13 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_MakerOptimizations/KK_Fix_MakerOptimizations.csproj
+++ b/src/KK_Fix_MakerOptimizations/KK_Fix_MakerOptimizations.csproj
@@ -2,17 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp-firstpass" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.TextMeshPro" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine.UI" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_MakerOptimizations_CursorManager\Core_Fix_MakerOptimizations_CursorManager.projitems" Label="Shared" />
 	<Import Project="..\Core_Fix_MakerOptimizations\Core_Fix_MakerOptimizations.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />

--- a/src/KK_Fix_ManifestCorrector/KK_Fix_ManifestCorrector.csproj
+++ b/src/KK_Fix_ManifestCorrector/KK_Fix_ManifestCorrector.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_ManifestCorrector\Core_Fix_ManifestCorrector.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_ModdedHeadEyeliner/KK_Fix_ModdedHeadEyeliner.csproj
+++ b/src/KK_Fix_ModdedHeadEyeliner/KK_Fix_ModdedHeadEyeliner.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_ModdedHeadEyeliner\Core_Fix_ModdedHeadEyeliner.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_NullChecks/KK_Fix_NullChecks.csproj
+++ b/src/KK_Fix_NullChecks/KK_Fix_NullChecks.csproj
@@ -2,19 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.Koikatu" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp-firstpass" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine.UI" Version="5.6.2.4" />
 		<PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.36.0" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_NullChecks\Core_Fix_NullChecks.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_PartyCardCompatibility/KK_Fix_PartyCardCompatibility.csproj
+++ b/src/KK_Fix_PartyCardCompatibility/KK_Fix_PartyCardCompatibility.csproj
@@ -2,12 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_PersonalityCorrector/KK_Fix_PersonalityCorrector.csproj
+++ b/src/KK_Fix_PersonalityCorrector/KK_Fix_PersonalityCorrector.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 	<Import Project="..\Core_Fix_PersonalityCorrector\Core_Fix_PersonalityCorrector.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_PoseLoad/KK_Fix_PoseLoad.csproj
+++ b/src/KK_Fix_PoseLoad/KK_Fix_PoseLoad.csproj
@@ -2,15 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.Koikatu" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_PoseLoad\Core_Fix_PoseLoad.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_ResourceUnloadOptimizations/KK_Fix_ResourceUnloadOptimizations.csproj
+++ b/src/KK_Fix_ResourceUnloadOptimizations/KK_Fix_ResourceUnloadOptimizations.csproj
@@ -2,15 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
 		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_ResourceUnloadOptimizations\Core_Fix_ResourceUnloadOptimizations.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_RestoreMissingFunctions/KK_Fix_RestoreMissingFunctions.csproj
+++ b/src/KK_Fix_RestoreMissingFunctions/KK_Fix_RestoreMissingFunctions.csproj
@@ -2,22 +2,15 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
 		<EmbeddedResource Include="CalendarIcon\action_icon_calendar_off.png" />
 		<EmbeddedResource Include="CalendarIcon\action_icon_calendar_on.png" />
 	</ItemGroup>
+
 	<ItemGroup>
-		<PackageReference Include="ExtensibleSaveFormat.Koikatu" Version="19.3.3" />
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp-firstpass" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine.UI" Version="5.6.2.4" />
 		<PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.36.0" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_RestoreMissingFunctions/RestoreMissingFunctions.cs
+++ b/src/KK_Fix_RestoreMissingFunctions/RestoreMissingFunctions.cs
@@ -20,7 +20,7 @@ namespace IllusionFixes
 {
     [BepInProcess(Constants.GameProcessName)]
     [BepInProcess(Constants.GameProcessNameSteam)]
-    [BepInDependency(KoikatuAPI.GUID, "1.7")]
+    [BepInDependency(KoikatuAPI.GUID, KoikatuAPI.VersionConst)]
     [BepInPlugin(GUID, PluginName, Constants.PluginsVersion)]
     public partial class RestoreMissingFunctions : BaseUnityPlugin
     {

--- a/src/KK_Fix_SettingsVerifier/KK_Fix_SettingsVerifier.csproj
+++ b/src/KK_Fix_SettingsVerifier/KK_Fix_SettingsVerifier.csproj
@@ -2,19 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<EmbeddedResource Include="Resources\setup.xml">
-			<SubType>Designer</SubType>
-		</EmbeddedResource>
+		<EmbeddedResource Include="Resources\setup.xml"/>
 	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_SettingsVerifier\Core_Fix_SettingsVerifier.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_ShowerAccessories/KK_Fix_ShowerAccessories.csproj
+++ b/src/KK_Fix_ShowerAccessories/KK_Fix_ShowerAccessories.csproj
@@ -2,14 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_ShowerAccessories\Core_Fix_ShowerAccessories.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_StudioOptimizations/KK_Fix_StudioOptimizations.csproj
+++ b/src/KK_Fix_StudioOptimizations/KK_Fix_StudioOptimizations.csproj
@@ -2,15 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine.UI" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_StudioOptimizations\Core_Fix_StudioOptimizations.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/KK_Fix_UnlimitedMapLights/KK-KKS_Fix_UnlimitedMapLights.csproj
+++ b/src/KK_Fix_UnlimitedMapLights/KK-KKS_Fix_UnlimitedMapLights.csproj
@@ -3,16 +3,19 @@
 		<TargetFramework>net35</TargetFramework>
 		<AssemblyName>KK_Fix_UnlimitedMapLights</AssemblyName>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.Koikatu.Assembly-CSharp" Version="2019.4.27.4" />
-		<PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
+		<PackageReference Update="ExtensibleSaveFormat.KoikatsuSunshine">
+			<ExcludeAssets>all</ExcludeAssets>
+		</PackageReference>
+		<PackageReference Update="IllusionLibs.KoikatsuSunshine.AllPackages">
+			<ExcludeAssets>all</ExcludeAssets>
+		</PackageReference>
 	</ItemGroup>
+
 	<Target Name="CopyOutputDll" AfterTargets="Build">
 		<Copy SourceFiles="$(TargetPath)" DestinationFiles="$(TargetDir)KKS_Fix_UnlimitedMapLights.dll" />
 	</Target>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/PH_Fix_CameraTarget/PH_Fix_CameraTarget.csproj
+++ b/src/PH_Fix_CameraTarget/PH_Fix_CameraTarget.csproj
@@ -2,13 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.PlayHome.Assembly-CSharp" Version="2018.3.11.4" />
-		<PackageReference Include="IllusionLibs.PlayHome.UnityEngine" Version="5.5.5.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Core_Fix_CameraTarget\Core_Fix_CameraTarget.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/PH_Fix_ResourceUnloadOptimizations/PH_Fix_ResourceUnloadOptimizations.csproj
+++ b/src/PH_Fix_ResourceUnloadOptimizations/PH_Fix_ResourceUnloadOptimizations.csproj
@@ -2,14 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
 		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="IllusionLibs.PlayHome.Assembly-CSharp" Version="2018.3.11.4" />
-		<PackageReference Include="IllusionLibs.PlayHome.UnityEngine" Version="5.5.5.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_ResourceUnloadOptimizations\Core_Fix_ResourceUnloadOptimizations.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/PH_Fix_SettingsVerifier/PH_Fix_SettingsVerifier.csproj
+++ b/src/PH_Fix_SettingsVerifier/PH_Fix_SettingsVerifier.csproj
@@ -2,23 +2,10 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-		<OutputPath>../../bin/BepInEx/plugins/IllusionFixes/</OutputPath>
-	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-		<OutputPath>../../bin/BepInEx/plugins/IllusionFixes/</OutputPath>
-	</PropertyGroup>
+
 	<ItemGroup>
-		<EmbeddedResource Include="Resources\setup.xml">
-			<SubType>Designer</SubType>
-		</EmbeddedResource>
+		<EmbeddedResource Include="Resources\setup.xml"/>
 	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
-		<PackageReference Include="IllusionLibs.PlayHome.Assembly-CSharp" Version="2018.3.11.4" />
-		<PackageReference Include="IllusionLibs.PlayHome.UnityEngine" Version="5.5.5.4" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
-	</ItemGroup>
+
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>

--- a/src/SBPR_Fix_ResourceUnloadOptimizations/SBPR_Fix_ResourceUnloadOptimizations.csproj
+++ b/src/SBPR_Fix_ResourceUnloadOptimizations/SBPR_Fix_ResourceUnloadOptimizations.csproj
@@ -2,14 +2,11 @@
 	<PropertyGroup>
 		<TargetFramework>net35</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-		<PackageReference Include="IllusionLibs.BepInEx.Harmony" Version="2.9.0" />
 		<PackageReference Include="IllusionLibs.BepInEx.MonoMod" Version="22.1.29.1" />
-		<PackageReference Include="IllusionLibs.SexyBeachPR.Assembly-CSharp" Version="2015.12.18" />
-		<PackageReference Include="IllusionLibs.SexyBeachPR.UnityEngine" Version="4.6.7" />
-		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.21.0" />
 	</ItemGroup>
+
 	<Import Project="..\Core_Fix_ResourceUnloadOptimizations\Core_Fix_ResourceUnloadOptimizations.projitems" Label="Shared" />
 	<Import Project="..\Common\Common.projitems" Label="Shared" />
 </Project>


### PR DESCRIPTION
- Moved common package references and analyzer dependencies into the shared `Directory.Build.props` file.
- Fixed the old disabled `PostBuildEvent` in `Directory.Build.props`.